### PR TITLE
Change /data owner to fix permission issues

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -27,6 +27,8 @@ ln -sf /config/config.yml /app/wiki/config.yml
 # permissions
 chown -R abc:abc \
 	/config
+chown -R abc:abc \
+	/data
 
 # chown the app directory, but not node_modules
 find /app/wiki -maxdepth 1 ! -name node_modules ! -name wiki -exec chown -R abc:abc '{}' \;

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -27,7 +27,7 @@ ln -sf /config/config.yml /app/wiki/config.yml
 # permissions
 chown -R abc:abc \
 	/config
-chown -R abc:abc \
+chown abc:abc \
 	/data
 
 # chown the app directory, but not node_modules


### PR DESCRIPTION
------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-wikijs/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The `/data` and `/config` directories are initially created as root, and the worker user (abc) does not have write permission. PR #4 made `abc` the owner for `/config`, but not `/data`. This fixes that.

## Benefits of this PR and context:
Closes #5, which was a permission issue relating to /data. 

## How Has This Been Tested?
```
docker build \
  --no-cache \
  --pull \
  -t linuxserver/wikijs:latest .
```
```
docker run \
  --name=wikijs \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=Europe/London \
  -p 3000:3000 \
  --rm \
  linuxserver/wikijs
```



## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
